### PR TITLE
Fix endpoint trailing slash

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -16,7 +16,7 @@ use ready2order\Exceptions\ResourceNotFoundException;
 class Client
 {
     private string $apiToken;
-    private string $apiEndpoint = 'https://api.ready2order.com/v1/';
+    private string $apiEndpoint = 'https://api.ready2order.com/v1';
     private int $timeout = 10;
 
     /**


### PR DESCRIPTION
The url generation has a bug: because the [$apiEndpoint](https://github.com/ready2order/r2o-api-client-php/blob/d72b99a9f402d30a640a75a8033da20965715e30/src/Client.php#L19) contains a trailing slash and [makeRequest](https://github.com/ready2order/r2o-api-client-php/blob/d72b99a9f402d30a640a75a8033da20965715e30/src/Client.php#L84) adds another slash, the resulting url for the method 'products' is for example https://api.ready2order.com/v1//products - which leads to a 404 response.