### PR TITLE
Fix get request parameters

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -31,27 +31,27 @@ class Client
 
     public function delete($method, $args = [], $timeout = 10): array
     {
-        return $this->makeRequest('delete', $method, $args, $timeout);
+        return $this->makeRequest('delete', $method, [RequestOptions::FORM_PARAMS => $args], $timeout);
     }
 
     public function get($method, $args = [], $timeout = 10): array
     {
-        return $this->makeRequest('get', $method, $args, $timeout);
+        return $this->makeRequest('get', $method, [RequestOptions::QUERY => $args], $timeout);
     }
 
     public function patch($method, $args = [], $timeout = 10): array
     {
-        return $this->makeRequest('patch', $method, $args, $timeout);
+        return $this->makeRequest('patch', $method, [RequestOptions::FORM_PARAMS => $args], $timeout);
     }
 
     public function post($method, $args = [], $timeout = 10): array
     {
-        return $this->makeRequest('post', $method, $args, $timeout);
+        return $this->makeRequest('post', $method, [RequestOptions::FORM_PARAMS => $args], $timeout);
     }
 
     public function put($method, $args = [], $timeout = 10): array
     {
-        return $this->makeRequest('put', $method, $args, $timeout);
+        return $this->makeRequest('put', $method, [RequestOptions::FORM_PARAMS => $args], $timeout);
     }
 
     public function setApiEndpoint(string $apiEndpoint): void
@@ -93,12 +93,11 @@ class Client
 
         try {
             $response = $client->request($method, $url, [
-                RequestOptions::HEADERS => [
-                    'Cache-Control' => 'no-cache',
-                    'Accept' => 'application/json',
-                ],
-                RequestOptions::FORM_PARAMS => $args,
-            ]);
+                    RequestOptions::HEADERS => [
+                        'Cache-Control' => 'no-cache',
+                        'Accept' => 'application/json',
+                    ],
+                ] + $args);
 
             $data = $this->parseJsonFromResponse($response);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ready2order;
+namespace ready2order\Tests;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;

--- a/tests/ProductsTest.php
+++ b/tests/ProductsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ready2order\Tests;
+namespace Tests;
 
 use ready2order\Exceptions\ErrorResponseException;
 
@@ -38,11 +38,14 @@ class ProductsTest extends AbstractTestCase
                 'productgroup_id' => $productGroup['productgroup_id'],
             ],
         ]);
-        $fetchedProduct = $client->get("products/{$product['product_id']}");
+        $fetchedProduct = $client->get("products/{$product['product_id']}", [
+            'includeProductGroup' => true
+        ]);
         $this->assertEquals($product['product_id'], $fetchedProduct['product_id']);
         $this->assertEquals($product['product_price'], $fetchedProduct['product_price']);
 
         $this->assertArrayHasKey('product_name', $product);
+        $this->assertArrayHasKey('productgroup', $fetchedProduct);
 
         // Update product with good values
         $testValues = [];


### PR DESCRIPTION
Get request parameters are currently not usable by the guzzle client (request uses [RequestOptions::FORM_PARAMS](https://github.com/ready2order/r2o-api-client-php/blob/98ad5e1bf468553ab1261c15d92f8f98ab286145/src/Client.php#L100) instead of [RequestOptions::QUERY](http://docs.guzzlephp.org/en/stable/request-options.html#query)).

This pr fixes the issue and verifies functionality with a small test adaptation.