### PR TITLE
Remove Tests namespace

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace ready2order\Tests;
+namespace ready2order;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;


### PR DESCRIPTION
use \ready2order\Client;
$client = new Client('your-token');

does not work because of the "\Tests" namespace.
Maybe this was used during development/testing but I guess it shouldn't be there any longer.