### PR TITLE
Move API endpoint configuration to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,10 @@ $client->setLanguage('en-US'); // English (default)
 
 ### Custom API Endpoint
 
-For testing or custom deployments:
+For testing or custom deployments, pass the endpoint as the second constructor parameter:
 
 ```php
-$client = new Client('your-token');
-$client->setApiEndpoint('https://custom-api.example.com/v1');
+$client = new Client('your-token', 'https://custom-api.example.com/v1');
 ```
 
 ## Error Handling

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,8 +19,10 @@ use ready2order\Exceptions\ResourceNotFoundException;
  */
 class Client
 {
+    private const DEFAULT_ENDPOINT = 'https://api.ready2order.com/v1';
+
     private string $apiToken;
-    private string $apiEndpoint = 'https://api.ready2order.com/v1';
+    private string $apiEndpoint;
     private int $timeout = 10;
     private string $language = 'en-US';
     private GuzzleClient $httpClient;
@@ -28,11 +30,13 @@ class Client
     /**
      * Create a new ready2order API client instance.
      *
-     * @param string $apiToken Your ready2order Account Token for API authentication
+     * @param string      $apiToken    Your ready2order Account Token for API authentication
+     * @param null|string $apiEndpoint Custom API endpoint URL (defaults to production API)
      */
-    public function __construct(string $apiToken)
+    public function __construct(string $apiToken, ?string $apiEndpoint = null)
     {
         $this->apiToken = $apiToken;
+        $this->apiEndpoint = $apiEndpoint ?? self::DEFAULT_ENDPOINT;
         $this->httpClient = new GuzzleClient([
             RequestOptions::HEADERS => [
                 'Authorization' => $this->apiToken,
@@ -131,20 +135,6 @@ class Client
     public function put($path, $args = [], $timeout = 10): array
     {
         return $this->makeRequest('put', $path, [RequestOptions::FORM_PARAMS => $args], $timeout);
-    }
-
-    /**
-     * Set a custom API endpoint URL.
-     *
-     * @param string $apiEndpoint Base URL for API requests (e.g., 'https://api.ready2order.com/v1')
-     *
-     * @return $this
-     */
-    public function setApiEndpoint(string $apiEndpoint): self
-    {
-        $this->apiEndpoint = $apiEndpoint;
-
-        return $this;
     }
 
     /**

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -39,8 +39,7 @@ abstract class AbstractTestCase extends TestCase
             }
 
             // initialize API wrapper
-            $this->api = new Client($accountToken);
-            $this->api->setApiEndpoint($endpoint);
+            $this->api = new Client($accountToken, $endpoint);
         }
 
         return $this->api;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -28,9 +28,6 @@ class ClientTest extends AbstractTestCase
 
         $result = $client->setLanguage('de-DE');
         self::assertSame($client, $result, 'setLanguage should return $this');
-
-        $result = $client->setApiEndpoint('https://api.ready2order.com/v1');
-        self::assertSame($client, $result, 'setApiEndpoint should return $this');
     }
 
     public function testFluentInterfaceChaining(): void
@@ -40,8 +37,7 @@ class ClientTest extends AbstractTestCase
         // Test that methods can be chained
         $result = $client
             ->setTimeout(15)
-            ->setLanguage('en-US')
-            ->setApiEndpoint($_ENV['R2O_API_ENDPOINT']);
+            ->setLanguage('en-US');
 
         self::assertSame($client, $result);
         self::assertSame(15, $client->getTimeout());


### PR DESCRIPTION
- Add optional $apiEndpoint parameter to constructor (nullable with default)
- Remove public setApiEndpoint() method
- Add DEFAULT_ENDPOINT constant for production API URL
- Update tests and documentation